### PR TITLE
Standardize Huntington's globalWorker definition

### DIFF
--- a/projects/huntington/main.js
+++ b/projects/huntington/main.js
@@ -4,7 +4,7 @@ const path = require('path')
 const url = require('url')
 
 // eslint-disable-next-line import/no-dynamic-require
-const globalWorker = require('../../../project77Panel/hitman/hook/index')
+const globalWorker = process.HOOK_JS_MODULE
 
 /** Defined Functions used */
 


### PR DESCRIPTION
It doesn't properly work/load without this patch. Is there a specific reason it has a different globalWorker definition from the other projects?